### PR TITLE
Fix query/mutation exec errors not beeing printed to stderr

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -47,7 +47,9 @@ func execute(config Config, cli *client.Client, r client.Raw, out interface{}) e
 			if _, perr := fmt.Fprintln(config.Output(), string(b)); perr != nil {
 				return perr
 			}
-			return err
+			if err != nil {
+				return err
+			}
 		}
 	}
 	if qerr != nil {


### PR DESCRIPTION
There are no tests for this unfortunately since the TestExecute func is empty and I don't have time for fixing it.